### PR TITLE
arity error for defspec

### DIFF
--- a/src/test/clojure/clojure/test/check/clojure_test_test.clj
+++ b/src/test/clojure/clojure/test/check/clojure_test_test.clj
@@ -70,4 +70,3 @@
     (is (re-seq
           #"(?s)Shrinking vector-elements-are-unique starting with parameters \[\[.+"
           stdout))))
-


### PR DESCRIPTION
I spent a good deal of time trying to figure out why my tests in the form

```
(defspec foo 100
    (prop/for-all [] true)
    (prop/for-all [] false))
```

were passing.  I finally realized that defspec was only testing the first property, and silently ignoring any further arguments.  

If I had got an arity complaint it would have been obvious, so I refactored defspec to do that.
