### PR TITLE
Adds :include-macros to intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ make sure this is the case:
 ```clojure
 (require '[clojure.test.check :as tc])
 (require '[clojure.test.check.generators :as gen])
-(require '[clojure.test.check.properties :as prop])
+
+;;  in Clojurescript do this instead:
+;; (require '[clojure.test.check.properties :as prop :include-macros true])
+ 
 
 (def sort-idempotent-prop
   (prop/for-all [v (gen/vector gen/int)]

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -18,7 +18,10 @@ the count of the input is preserved. Our test might look like:
 ```clojure
 (require '[clojure.test.check :as tc]
          '[clojure.test.check.generators :as gen]
-         '[clojure.test.check.properties :as prop])
+         '[clojure.test.check.properties :as prop]
+      ;;  in Clojurescript do this instead:
+      ;; '[clojure.test.check.properties :as prop :include-macros true]
+         )
 
 (def property
   (prop/for-all [v (gen/vector gen/int)]


### PR DESCRIPTION
It might be confusing for those who try test.check from Clojurescript REPL,
the example will fail. I think adding a comment would be helpful.